### PR TITLE
Remove `cyrillic` command, use babel instead

### DIFF
--- a/mystd.sty
+++ b/mystd.sty
@@ -1,6 +1,6 @@
 \ProvidesPackage{mystd}
 
-\usepackage{amsmath,amssymb,amsthm,amsfonts}
+\usepackage{mathtools,amssymb,amsthm,amsfonts}
 \usepackage[svgnames,dvipsnames]{xcolor}
 
 \definecolor{AccColor1}{HTML}{C41E3A}     %#C41E3A
@@ -62,19 +62,16 @@
 
 \ProcessOptions\relax
 
-\ifstdpolish
-    \usepackage[polish]{babel}
-\fi
 
 \usepackage{fontspec}
-\newfontfamily{\cyrillic}[
-    UprightFont=*rm,
-    BoldFont=*bx,
-    ItalicFont=*ti,
-    BoldItalicFont=*bi,
+\defaultfontfeatures[CMU Serif]{
+    UprightFont=cmunrm,
+    BoldFont=cmunbx,
+    ItalicFont=cmunti,
+    BoldItalicFont=cmunbi,
     Extension=.otf,
     Ligatures=TeX
-]{cmun}
+}
 \ifstdmonofont
     \setmonofont{JetBrainsMono}[
         Path=./fonts/,
@@ -86,6 +83,13 @@
         BoldItalicFont=*-BoldItalic
     ]
 \fi
+
+\ifstdpolish
+    \usepackage[polish]{babel}
+\else
+    \usepackage[american]{babel}
+\fi
+\babelfont[russian]{rm}{CMU Serif}
 
 %  ----------  SHORT AND USEFUL STUFF  ----------  %
 
@@ -324,7 +328,6 @@
 \usepackage[shortlabels]{enumitem}
 \usepackage{multirow}
 \usepackage{multicol}
-\usepackage{mathtools}
 \usepackage{microtype}
 \usepackage[color=ColAccBad!70]{todonotes}
 

--- a/src/algebra/lec3_structures.tex
+++ b/src/algebra/lec3_structures.tex
@@ -131,7 +131,8 @@ Drugie działanie nazywamy \vocab{działaniem multiplikatywnym} i oznaczamy prze
     Ciało to pierścień z jedynką, w którym dla każdego elementu $x \neq \mathbf{0}$ istnieje element odwrotny $x^{-1}$.
 \end{definition}
 
-\vocab{Ciałem przemiennym} będzie takie ciało, w którym działanie multiplikatywne $\cdot$ jest przemienne\footnote{Większość autorów już w definicji ciała wymaga przemienności (wtedy ciało nazywamy pierścieniem z~dzieleniem). Przyjęło się tak zwłaszcza w literaturze angielskiej (ciało przemienne to \textit{field}, a ciało to \textit{division ring} lub \textit{skew field}) i niemieckiej (odpowiednio \textit{Körper} i \textit{Schiefkörper}). Odwrotnie --- czyli zgodnie z naszą konwencją --- jest w literaturze francuskiej (odpowiednio \textit{corps commutatif} i \textit{corps}) oraz rosyjskiej (\cyrillic{\textit{поле}} [pole] i \cyrillic{\textit{тело}} [tieło]).}.
+\vocab{Ciałem przemiennym} będzie takie ciało, w którym działanie multiplikatywne $\cdot$ jest przemienne\footnote{Większość autorów już w definicji ciała wymaga przemienności (wtedy ciało nazywamy pierścieniem z~dzieleniem). Przyjęło się tak zwłaszcza w literaturze angielskiej (ciało przemienne to \textit{field}, a ciało to \textit{division ring} lub \textit{skew field}) i niemieckiej (odpowiednio \textit{Körper} i \textit{Schiefkörper}).
+Odwrotnie --- czyli zgodnie z naszą konwencją --- jest w literaturze francuskiej (odpowiednio \textit{corps commutatif} i \textit{corps}) oraz rosyjskiej (\textit{\foreignlanguage{russian}{поле}} [pole] i \textit{\foreignlanguage{russian}{тело}} [tieło]).}.
 
 Można zauważyć, że struktura $(K, +, \cdot)$ jest ciałem (przemiennym), jeżeli:
 \begin{enumerate}[noitemsep,nolistsep]


### PR DESCRIPTION
Currently using Latin Modern as a default and Computer Modern Unicode (CMU Serif) for cyrillic.