### PR TITLE
Theme fix

### DIFF
--- a/mystd.sty
+++ b/mystd.sty
@@ -63,7 +63,7 @@
 \ProcessOptions\relax
 
 \usepackage{fontsetup}  % loads fontspec and New Computer Modern
-\usepackage[scale=0.9]{raleway}  % loads Raleway sans serif font
+\usepackage{raleway}  % loads Raleway sans serif font
 \ifstdmonofont
     \setmonofont{JetBrainsMono}[Scale=0.85]
 \fi
@@ -175,7 +175,7 @@
     \mdfdefinestyle{mdbluebox}{%
         skipabove=12pt,
         skipbelow=2pt,
-        linewidth=0.5pt,
+        linewidth=0.75pt,
         innerbottommargin=9pt,
         linecolor=BoxColor1,
         backgroundcolor=BoxColor1!5,
@@ -199,7 +199,7 @@
         nobreak=true
     }
     \declaretheoremstyle[
-        headfont=\bfseries\color{BoxColor2},
+        headfont=\sffamily\bfseries\color{BoxColor2},
         bodyfont=\normalfont\small,
         mdframed={style=mdredbox},
         headpunct={\\[3pt]},
@@ -216,11 +216,11 @@
         backgroundcolor=black!3,
     }
     \declaretheoremstyle[
-        headfont=\bfseries,
+        headfont=\sffamily\bfseries,
         bodyfont=\normalfont\small,
         mdframed={style=mdblackbox},
-        spaceabove=0pt,
-        spacebelow=0pt
+        headpunct={\\[3pt]},
+        postheadspace={0pt}
     ]{thmblackbox}
 \else
     \declaretheoremstyle[headfont=\bfseries,bodyfont=\normalfont,spaceabove=\topsep,spacebelow=\topsep]{thmbluebox}

--- a/mystd.sty
+++ b/mystd.sty
@@ -75,6 +75,10 @@
         % you can still use \le and \ge for the standard versions
         \renewcommand{\leq}{\leqslant}
         \renewcommand{\geq}{\geqslant}
+        \renewcommand{\nleq}{\nleqslant}
+        \renewcommand{\ngeq}{\ngeqslant}
+        \renewcommand{\preceq}{\preccurlyeq}
+        \renewcommand{\succeq}{\succcurlyeq}
     }
 \else
     \usepackage[american]{babel}
@@ -130,6 +134,7 @@
 \newcommand{\sL}{{\symcal L}}
 \newcommand{\sM}{{\symcal M}}
 \newcommand{\sO}{{\symcal O}}
+\newcommand{\sP}{{\symcal P}}
 \newcommand{\sR}{{\symcal R}}
 \newcommand{\sS}{{\symcal S}}
 
@@ -324,7 +329,7 @@
 \usepackage{multirow}
 \usepackage{multicol}
 \usepackage{microtype}
-\usepackage[color=ColAccBad!70]{todonotes}
+\usepackage[color=ColAccBad!70,textsize=footnotesize]{todonotes}
 
 \addtokomafont{subtitle}{\Large}
 \setkomafont{author}{\Large}


### PR DESCRIPTION
Changes:
* full-scale Raleway font
* slanted `\nleq`, `\preceq`, ...
* sans-serif example and remark titles
* ...